### PR TITLE
Remove `---` from clinics selection widget

### DIFF
--- a/whoahqa/forms/user_form.py
+++ b/whoahqa/forms/user_form.py
@@ -42,11 +42,9 @@ def state_selection_widget(node, kw):
 
 @colander.deferred
 def clinic_selection_widget(node, kw):
-    values = [('', '---')]
-    [values.append((c.id, key_to_label(c.name + " - " + c.code)))
-     for c in Clinic.all()]
     return SelectWidget(
-        values=values,
+        values=[(c.id, key_to_label(c.name + " - " + c.code))
+                for c in Clinic.all()],
         multiple=True)
 
 


### PR DESCRIPTION
Remove `---` from clinics select widget (multiple) because it is selectable in the clinics' list, which triggers a validation error.

Signed-off-by: Kipchirchir Sigei <arapgodsmack@gmail.com>