### PR TITLE
Raise `IntegrityError` when duplicate unique key is found

### DIFF
--- a/whoahqa/templates/base.jinja2
+++ b/whoahqa/templates/base.jinja2
@@ -146,7 +146,7 @@ Purchase: http://themeforest.net/item/conquer-responsive-admin-dashboard-templat
                            selected
                         {% endif %}">
                         <a href="{{ request.route_url('locations', traverse=('')) }}">
-                        {{gettext('List Locations')}}</a>
+                        {{gettext('Manage Locations')}}</a>
                      </li>
                      <li class="
                         {%if request.url.find('manage') != -1 %}

--- a/whoahqa/templates/clinics_edit.jinja2
+++ b/whoahqa/templates/clinics_edit.jinja2
@@ -1,9 +1,13 @@
 {% extends 'base.jinja2' %}
-{% block title %}Edit User{% endblock %}
+{% block title %}Edit Clinic{% endblock %}
 {% block page_title %} {{ self.title() }} {% endblock %}
 {% block breadcrumbs %}
     <li><i class="icon-angle-right"></i></li>
-    <li class="active">{{ gettext("Manage Clinics")}}</li>
+    <li class="active">
+    <a href="{{ request.route_url('clinics', traverse=('manage')) }}">
+      {{ gettext("Manage Clinics")}}
+    </a>
+    </li>
     <li><i class="icon-angle-right"></i></li>
     <li>{{clinic.name or "New Clinic"}}</li>
 {% endblock %}

--- a/whoahqa/views/clinics.py
+++ b/whoahqa/views/clinics.py
@@ -245,7 +245,7 @@ class ClinicViews(BaseClassViews):
                                   values.get('code'),
                                   municipality)
                     self.request.session.flash(
-                        _("{} Clinic saved.".format(clinic.name)), "success")
+                        _("{} saved.".format(clinic.name)), "success")
 
                     return HTTPFound(
                         self.request.route_url(
@@ -255,12 +255,13 @@ class ClinicViews(BaseClassViews):
                 except NoResultFound:
                     self.request.session.flash(
                         _("Cannot find selected municipality."), "error")
+
                 except IntegrityError:
                     DBSession.rollback()
 
                     self.request.session.flash(
                         _("A clinic already exists with the \
-                          provided name or CNES."),
+                          provided CNES."),
                         "error")
 
         return {
@@ -298,11 +299,19 @@ class ClinicViews(BaseClassViews):
                                   values.get('code'),
                                   municipality)
                     self.request.session.flash(
-                        _("{} Clinic updated.".format(clinic.name)), "success")
+                        _("{} updated.".format(clinic.name)), "success")
 
                 except NoResultFound:
                     self.request.session.flash(
                         _("Cannot find selected municipality."), "error")
+
+                except IntegrityError:
+                    DBSession.rollback()
+
+                    self.request.session.flash(
+                        ("A clinic already exists with the \
+                          provided CNES."),
+                        "error")
 
         period = get_period_from_request(self.request)
 


### PR DESCRIPTION
- fix 502 error being thrown when editing cnes to an existing one
- update duplicate cnes error message
- change `Edit User` to `Edit Clinic`
- Remove redundant `clinic` string in clinic registration success flash message

Addresses https://github.com/onaio/who-adolescent-hqa/issues/200#issuecomment-311636526

Signed-off-by: Kipchirchir Sigei <arapgodsmack@gmail.com>